### PR TITLE
Fix CI builds on Ubuntu 24.04

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
-      - name: cargo fmt --check
-        run: cargo fmt --check
+      - name: cargo +stable fmt --check
+        run: cargo +stable fmt --check
   clippy:
     runs-on: ubuntu-latest
     name: ${{ matrix.toolchain }} / clippy
@@ -55,25 +55,26 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
-      - name: cargo clippy
+      - name: cargo +${{ matrix.toolchain }} clippy
         uses: giraffate/clippy-action@13b9d32482f25d29ead141b79e7e04e7900281e0 # tag=v1.0.1
         with:
           reporter: "github-pr-check"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-  semver:
-    runs-on: ubuntu-latest
-    name: semver
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
-        with:
-          submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # branch=master
-        with:
-          toolchain: stable
-          components: rustfmt
-      - name: cargo-semver-checks
-        uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # tag=v2.8
+  # TODO(anri): the crate is not public, so this check will always fail.
+  # semver:
+  #   runs-on: ubuntu-latest
+  #   name: semver
+  #   steps:
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
+  #       with:
+  #         submodules: true
+  #     - name: Install stable
+  #       uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # branch=master
+  #       with:
+  #         toolchain: stable
+  #         components: rustfmt
+  #     - name: cargo-semver-checks
+  #       uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # tag=v2.8
   doc:
     # run docs generation on nightly rather than stable. This enables features like
     # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an
@@ -112,7 +113,7 @@ jobs:
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       # --feature-powerset runs for every combination of features
       - name: cargo hack
-        run: cargo hack --feature-powerset check
+        run: cargo +stable hack --feature-powerset check
   msrv:
     # check that we can build using the minimal rust version that is specified by this crate
     runs-on: ubuntu-latest
@@ -134,5 +135,5 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-cargo
-      - name: cargo +${{ matrix.msrv }} check
-        run: cargo check
+      - name: cargo check
+        run: cargo +${{ matrix.msrv }} check

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -26,11 +26,16 @@ jobs:
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # branch=master
         with:
           toolchain: nightly
-      - name: cargo generate-lockfile
+      - name: cargo +nightly generate-lockfile
         if: hashFiles('Cargo.lock') == ''
-        run: cargo generate-lockfile
+        run: cargo +nightly generate-lockfile
+      - name: Install CMake
+        run: |
+          sudo apt update && sudo apt install -y cmake gcc-14 g++-14
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 20
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 20
       - name: cargo test --locked
-        run: cargo test --locked --all-features --all-targets
+        run: cargo +nightly test --locked --all-features --all-targets
   # https://twitter.com/alcuadrado/status/1571291687837732873
   update:
     # This action checks that updating the dependencies of this crate to the latest available that
@@ -54,9 +59,14 @@ jobs:
           toolchain: beta
       - name: cargo update
         if: hashFiles('Cargo.lock') != ''
-        run: cargo update
+        run: cargo +beta update
+      - name: Install CMake
+        run: |
+          sudo apt update && sudo apt install -y cmake gcc-14 g++-14
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 20
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 20
       - name: cargo test
         if: hashFiles('Cargo.lock') != ''
-        run: cargo test --locked --all-features --all-targets
+        run: cargo +beta test --locked --all-features --all-targets
         env:
           RUSTFLAGS: -D deprecated

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,13 +36,18 @@ jobs:
       - name: cargo generate-lockfile
         # enable this ci template to run regardless of whether the lockfile is checked in or not
         if: hashFiles('Cargo.lock') == ''
-        run: cargo generate-lockfile
+        run: cargo +${{ matrix.toolchain }} generate-lockfile
+      - name: Install CMake
+        run: |
+          sudo apt update && sudo apt install -y cmake gcc-14 g++-14
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 20
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 20
       # https://twitter.com/jonhoo/status/1571290371124260865
       - name: cargo test --locked
-        run: cargo test --locked --all-features --all-targets
+        run: cargo +${{ matrix.toolchain }} test --locked --all-features --all-targets
       # https://github.com/rust-lang/cargo/issues/6669
       - name: cargo test --doc
-        run: cargo test --locked --all-features --doc
+        run: cargo +${{ matrix.toolchain }} test --locked --all-features --doc
   minimal:
     # This action chooses the oldest version of the dependencies permitted by Cargo.toml to ensure
     # that this crate is compatible with the minimal version that this crate and its dependencies
@@ -84,8 +89,13 @@ jobs:
         run: rustup default stable
       - name: cargo update -Zminimal-versions
         run: cargo +nightly update -Zminimal-versions
+      - name: Install CMake
+        run: |
+          sudo apt update && sudo apt install -y cmake gcc-14 g++-14
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 20
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 20
       - name: cargo test
-        run: cargo test --locked --all-features --all-targets
+        run: cargo +stable test --locked --all-features --all-targets
   os-check:
     # run cargo test on mac and windows
     runs-on: ${{ matrix.os }}
@@ -110,9 +120,9 @@ jobs:
           toolchain: stable
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
-        run: cargo generate-lockfile
+        run: cargo +stable generate-lockfile
       - name: cargo test
-        run: cargo test --locked --all-features --all-targets
+        run: cargo +stable test --locked --all-features --all-targets
   # coverage:
   #   # use llvm-cov to build and collect coverage and outputs in a format that
   #   # is compatible with codecov.io

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,18 +215,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clean-path"
@@ -699,9 +699,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -929,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -1323,12 +1323,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1607,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -1914,18 +1914,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/assets/runtime/cpp/CMakeLists.txt
+++ b/assets/runtime/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 3.31)
 project(pkgen_cpp)
 
 set(CMAKE_CXX_STANDARD 23) # glaze requires C++23 or greater

--- a/assets/runtime/cpp/pkgen_helpers.hpp
+++ b/assets/runtime/cpp/pkgen_helpers.hpp
@@ -9,8 +9,12 @@
 #include <sstream>
 #include <array>
 #include <unordered_map>
+#include <vector>
 
-#if __cplusplus <= 201703L
+#include <charconv>
+#include <version>
+
+#if  __cpp_lib_chrono < 201907L
 #include "date.h" // now standard in c++20 ^^
 #endif
 
@@ -48,7 +52,7 @@ static bool string_to_chrono(std::string_view in,
   std::string a = std::string(in);
   std::istringstream iss(a);
 
-#if __cplusplus <= 201703L
+#if __cpp_lib_chrono < 201907L
   iss >> date::parse("%F %T", out);
 #else
   iss >> std::chrono::parse("%F %T", out);
@@ -60,7 +64,7 @@ static bool string_to_chrono(std::string_view in,
 static bool chrono_to_string(const chrono_time &in,
                                        std::string &out) {
   try {
-#if __cplusplus <= 201703L
+#if __cpp_lib_chrono < 201907L
     const auto floor = date::floor<std::chrono::seconds>(in);
     out = date::format("%F %T", floor);
 #else

--- a/packet-generator-cli/Cargo.toml
+++ b/packet-generator-cli/Cargo.toml
@@ -16,7 +16,7 @@ miette = { workspace = true }
 itertools = { workspace = true }
 thiserror = { workspace = true }
 
-mimalloc = { version = "*", optional = true }
+mimalloc = { version = "0.1.37", optional = true }
 
 [features]
 mimalloc = ["dep:mimalloc"]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -31,6 +31,8 @@ fn create_file(path: impl AsRef<Path>, content: &str) {
 }
 
 fn generic_e2e_cxx_glaze_harness(path_entrypoint: PathBuf, test_name: &str) {
+    let glaze_version = std::env::var("GLAZE_VERSION").unwrap_or_else(|_| String::from("v7.2.0"));
+
     let (defs, _) = setup_e2e_registry(path_entrypoint);
 
     let generation_basepath =
@@ -56,9 +58,9 @@ fn generic_e2e_cxx_glaze_harness(path_entrypoint: PathBuf, test_name: &str) {
         let test_name = test_name.to_snake_case();
         let cmake_file_content = format!(
             r#"
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.31)
 project(kdl_generator_e2e_{test_name}_test_suite)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
@@ -66,7 +68,7 @@ include(FetchContent)
 FetchContent_Declare(
   glaze
   GIT_REPOSITORY https://github.com/stephenberry/glaze.git
-  GIT_TAG main
+  GIT_TAG {glaze_version}
   GIT_SHALLOW TRUE
 )
 
@@ -78,11 +80,13 @@ else()
     set(CMAKE_CXX_FLAGS "${{CMAKE_CXX_FLAGS}} -Wall -fno-permissive")
 endif()
 
+add_subdirectory("${{CMAKE_CURRENT_SOURCE_DIR}}/../../assets/runtime/cpp" "${{CMAKE_CURRENT_BINARY_DIR}}/pkgen")
+
 add_executable(${{PROJECT_NAME}}
     main.cpp
 )
-target_include_directories(${{PROJECT_NAME}} PRIVATE "{runtime_dir}")
-target_link_libraries(${{PROJECT_NAME}} PRIVATE glaze::glaze)
+target_link_libraries(${{PROJECT_NAME}} PRIVATE glaze::glaze pkgen_cpp)
+target_compile_features(${{PROJECT_NAME}} PUBLIC cxx_std_23)
     "#
         );
 


### PR DESCRIPTION
Ubuntu uses GCC 13 by default, which has a broken implementation of `std::chrono::parse`. I fixed the CI tests by installing GCC 14 and explicitly passing the toolchains.