### PR TITLE
Parametrize array by size

### DIFF
--- a/assets/net/handlers.kdl
+++ b/assets/net/handlers.kdl
@@ -27,6 +27,7 @@ import "../net/daily_login.kdl"
 import "../net/summonerjournaluserinfo.kdl"
 import "../net/userinfo.kdl"
 import "../net/items.kdl"
+import "../net/logincampaign.kdl"
 
 json InitializeReq {
     doc "Initialization command"
@@ -312,7 +313,7 @@ json UserInfoResp {
         key "fEi17cnx"
         doc "TODO"
     }
-    
+
 	field unitInfo type="[UserUnitInfo]" {
         key "4ceMWH6k"
         doc "TODO"

--- a/assets/runtime/cpp/pkgen_glaze_helpers.hpp
+++ b/assets/runtime/cpp/pkgen_glaze_helpers.hpp
@@ -46,6 +46,19 @@ template <auto MemPtr> constexpr decltype(auto) single_array() {
         };
 }
 
+// template <class T, uintmax_t N> struct fixed_array_helper {
+//     std::array<T, N>  &val; // reference to the data
+// };
+//
+// template <auto MemPtr> constexpr decltype(auto) fixed_array() {
+//     return [](auto&& val) {
+//         using T = std::decay_t<decltype(val.*MemPtr)>;
+//         return single_array_helper<T>{
+//             const_cast<T&>(val.*MemPtr) }; // NOTE(arves): this is a crappy thing yes...
+//         };
+// }
+
+
 template <class T> struct bool_as_string_helper {
   std::string as_str;
   T &val; // reference to the boolean

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -105,8 +105,8 @@ fn build_gamefrontier_input() -> (&'static str, PathBuf, ParserOpts<InMemoryFS>)
         include_str!("../assets/mst/firstdesc.kdl"),
     );
     let _ = fs.add_file(
-        VfsPath::new("mst/gatcha.kdl"),
-        include_str!("../assets/mst/gatcha.kdl"),
+        VfsPath::new("mst/gacha.kdl"),
+        include_str!("../assets/mst/gacha.kdl"),
     );
     let _ = fs.add_file(
         VfsPath::new("mst/gift.kdl"),
@@ -119,6 +119,22 @@ fn build_gamefrontier_input() -> (&'static str, PathBuf, ParserOpts<InMemoryFS>)
     let _ = fs.add_file(
         VfsPath::new("mst/noticeinfo.kdl"),
         include_str!("../assets/mst/noticeinfo.kdl"),
+    );
+    let _ = fs.add_file(
+        VfsPath::new("mst/info.kdl"),
+        include_str!("../assets/mst/info.kdl"),
+    );
+    let _ = fs.add_file(
+        VfsPath::new("mst/trophy.kdl"),
+        include_str!("../assets/mst/trophy.kdl"),
+    );
+    let _ = fs.add_file(
+        VfsPath::new("mst/help.kdl"),
+        include_str!("../assets/mst/help.kdl"),
+    );
+    let _ = fs.add_file(
+        VfsPath::new("mst/frontier_hunter.kdl"),
+        include_str!("../assets/mst/frontier_hunter.kdl"),
     );
     let _ = fs.add_file(
         VfsPath::new("mst/npc.kdl"),

--- a/src/generators/cpp.rs
+++ b/src/generators/cpp.rs
@@ -7,7 +7,7 @@ use stringcase::Caser;
 use crate::generators::{Addon, GeneratedSource, GenerationError, Generator, WithAddons};
 
 use crate::intermediate::{
-    DataType, Definition, DefinitionRegistry, IntEnum, Json, JsonField, StringEnum,
+    ArraySize, DataType, Definition, DefinitionRegistry, IntEnum, Json, JsonField, StringEnum,
 };
 
 const AUTOGENERATION_NOTICE: &str = "
@@ -190,15 +190,6 @@ fn convert_datatype(
 
         DataType::String => Ok(String::from("std::string")),
 
-        DataType::StringArray {
-            inner_type,
-            separator: _,
-        } => {
-            let inner = convert_datatype(inner_type, registry)?;
-
-            Ok(format!("pkg::string_list<{inner}>"))
-        }
-
         DataType::Datetime | DataType::DatetimeUnix => Ok(String::from("pkg::chrono_time")),
 
         DataType::Map { key, value } => {
@@ -208,18 +199,55 @@ fn convert_datatype(
             Ok(format!("std::unordered_map<{key}, {value}>"))
         }
 
-        DataType::Array { inner_type } => {
+        DataType::Array {
+            inner_type,
+            size: ArraySize::Dynamic,
+        } => {
             let inner = convert_datatype(inner_type, registry)?;
 
             Ok(format!("std::vector<{inner}>"))
         }
 
-        DataType::SingleElementArray { inner_type } => {
+        DataType::Array {
+            inner_type,
+            size: ArraySize::Fixed(size),
+        } => {
             let inner = convert_datatype(inner_type, registry)?;
-            Ok(inner)
+
+            match size.get() {
+                1 => Ok(inner),
+                n => Ok(format!("std::array<{inner}, {n}>")),
+            }
         }
 
-        DataType::Definition(weak) => {
+        DataType::StringArray {
+            inner_type,
+            separator: _,
+            size: ArraySize::Dynamic,
+        } => {
+            let inner = convert_datatype(inner_type, registry)?;
+
+            Ok(format!("pkg::string_list<{inner}>"))
+        }
+
+        DataType::StringArray {
+            inner_type: _,
+            separator: _,
+            size: ArraySize::Fixed(_),
+        } => {
+            // TODO(Arves): Implement this.
+            todo!("Fixed array size for string arrays are not implemented.");
+        }
+
+        // DataType:: { inner_type } => {
+        //     let inner = convert_datatype(inner_type, registry)?;
+        //     Ok(inner)
+        // }
+        DataType::Definition {
+            definition: weak,
+            // TODO(anri): Handle JSON string encoding
+            encoding: _,
+        } => {
             let definition = registry.get(*weak);
             match *definition {
                 Definition::StringEnum(ref str_enum) => Ok(format!("{}::Type", str_enum.name)),
@@ -228,7 +256,7 @@ fn convert_datatype(
             }
         }
 
-        DataType::Unknown(other) => match registry.find(other) {
+        DataType::Unknown { name: other, .. } => match registry.find(other) {
             Some((definition, _idx)) => match definition {
                 Definition::StringEnum(str_enum) => Ok(format!("{}::Type", str_enum.name)),
 

--- a/src/generators/glaze.rs
+++ b/src/generators/glaze.rs
@@ -4,7 +4,8 @@ use stringcase::Caser;
 use crate::generators::{Addon, CxxGenerator, GenerationError};
 
 use crate::intermediate::{
-    ArraySeparator, BoolEncoding, DataType, Definition, DefinitionRegistry, Encoding, Json,
+    ArraySeparator, ArraySize, BoolEncoding, DataType, Definition, DefinitionRegistry, Encoding,
+    Json,
 };
 
 const TAB: &str = "    ";
@@ -54,6 +55,7 @@ const fn get_glz_array_separator(sep: ArraySeparator) -> char {
         ArraySeparator::Comma => ',',
         ArraySeparator::At => '@',
         ArraySeparator::Colon => ':',
+        ArraySeparator::Pipe => '|',
     }
 }
 
@@ -92,17 +94,32 @@ fn get_glz_mapper(
         } => Ok(format!("glz::bools_as_numbers<&T::{name}>")),
         DataType::Datetime => Ok(format!("pkg::glaze::datetime<&T::{name}>()")),
         DataType::DatetimeUnix => Ok(format!("pkg::glaze::datetime_unix<&T::{name}>()")),
-        DataType::SingleElementArray { inner_type: _ } => {
-            Ok(format!("pkg::glaze::single_array<&T::{name}>()"))
-        }
+
+        DataType::Array {
+            size: ArraySize::Fixed(n),
+            inner_type: _,
+        } => match n.get() {
+            1 => Ok(format!("pkg::glaze::single_array<&T::{name}>()")),
+            _ => Ok(format!("&T::{name}")),
+        },
+
         DataType::StringArray {
             inner_type: _,
             separator,
+            size: ArraySize::Dynamic,
         } => {
             let glz_sep = get_glz_array_separator(*separator);
             Ok(format!(
                 "pkg::glaze::array_string<T, &T::{name}, '{glz_sep}'>"
             ))
+        }
+
+        DataType::StringArray {
+            inner_type: _,
+            separator: _,
+            size: ArraySize::Fixed(_),
+        } => {
+            todo!("Fixed-length string arrays are not implemented.");
         }
 
         // NOTE(arves) => For custom encoding one should override the specific concepts

--- a/src/intermediate/mod.rs
+++ b/src/intermediate/mod.rs
@@ -6,6 +6,8 @@ use std::{
     sync::Arc,
 };
 
+use core::num::NonZeroUsize;
+
 use miette::SourceSpan;
 use petgraph::{
     algo::toposort, graph::NodeIndex, prelude::StableDiGraph, stable_graph::NodeIndices,
@@ -56,6 +58,12 @@ impl Definition {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum JsonEncoding {
+    Json,
+    String,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Json {
     pub index: usize,
@@ -65,6 +73,7 @@ pub struct Json {
     pub doc: String,
     pub source: Arc<SourceInfo>,
     pub span: SourceSpan,
+    pub encoding: JsonEncoding,
 }
 
 impl Borrow<str> for Json {
@@ -144,6 +153,7 @@ impl Json {
             doc,
             source: defined_in_source,
             span: defined_in_span,
+            encoding: JsonEncoding::Json,
         }
     }
 
@@ -252,12 +262,29 @@ pub enum ArraySeparator {
     /// [i32] = "1@3@4@5@6"
     At,
 
+    /// Array separated by '|'
+    ///
+    /// ## Example
+    ///
+    /// [i32] = "1|3|4|5|6"
+    Pipe,
+
     /// Array separated by ':'
     ///
     /// ## Example
     ///
     /// [i32] = "1:3:4:5:6"
     Colon,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum ArraySize {
+    #[default]
+    /// Unbounded array size.
+    Dynamic,
+
+    /// Fixed array size.
+    Fixed(NonZeroUsize),
 }
 
 #[derive(Clone, Debug)]
@@ -302,19 +329,44 @@ pub enum DataType {
     StringArray {
         inner_type: Arc<Self>,
         separator: ArraySeparator,
+        size: ArraySize,
     },
 
     Array {
         inner_type: Arc<Self>,
+        size: ArraySize,
     },
 
-    SingleElementArray {
-        inner_type: Arc<Self>,
+    Definition {
+        encoding: JsonEncoding,
+        definition: DefinitionRef,
     },
 
-    Definition(DefinitionRef),
+    Unknown {
+        encoding: JsonEncoding,
+        name: String,
+    },
+}
 
-    Unknown(String),
+fn extract_dependency_from_field(data_type: &DataType) -> Vec<DefinitionRef> {
+    let mut ret = vec![];
+
+    match data_type {
+        DataType::Definition { definition, .. } => ret.push(*definition),
+
+        DataType::Array { inner_type, .. } | DataType::StringArray { inner_type, .. } => {
+            ret.append(&mut extract_dependency_from_field(inner_type.as_ref()));
+        }
+
+        DataType::Map { key, value } => {
+            ret.append(&mut extract_dependency_from_field(key.as_ref()));
+            ret.append(&mut extract_dependency_from_field(value.as_ref()));
+        }
+
+        _ => {}
+    }
+
+    ret
 }
 
 #[derive(Debug, Clone)]
@@ -372,6 +424,36 @@ impl PartialDefinitionRegistry {
         }
     }
 
+    pub fn insert(&mut self, definition: Definition) -> DefinitionRef {
+        #[allow(clippy::single_match_else, reason = "May add more cases in the future")]
+        match definition {
+            Definition::Json(ref json) => {
+                let mut dependencies = vec![];
+
+                for field in &json.fields {
+                    dependencies.append(&mut extract_dependency_from_field(&field.type_));
+                }
+
+                let name = definition.name().clone();
+                let this_def_idx = self.definitions.add_node(definition);
+                self.names.insert(name, this_def_idx);
+                for &dependency in &dependencies {
+                    self.definitions.add_edge(dependency, this_def_idx, ());
+                }
+
+                this_def_idx
+            }
+
+            _ => {
+                let name = definition.name().clone();
+                let idx = self.definitions.add_node(definition);
+                self.names.insert(name, idx);
+
+                idx
+            }
+        }
+    }
+
     /// Validates the current incomplete registry to build a
     /// [`DefinitionRegistry`].
     ///
@@ -393,7 +475,7 @@ impl PartialDefinitionRegistry {
                     .map(|field| -> Result<_, Diagnostic> {
                         let mut f = field.clone();
 
-                        if let DataType::Unknown(name) = &field.type_ {
+                        if let DataType::Unknown { encoding, name } = &field.type_ {
                             let idx = self.names.get(name).ok_or_else(|| Diagnostic {
                                 message: format!("could not find definition `{name}`"),
                                 severity: miette::Severity::Error,
@@ -415,7 +497,10 @@ impl PartialDefinitionRegistry {
                                 }],
                             })?;
 
-                            f.type_ = DataType::Definition(*idx);
+                            f.type_ = DataType::Definition {
+                                encoding: *encoding,
+                                definition: *idx,
+                            };
 
                             let Some(target_definition) = self.names.get(&json.name) else {
                                 return Err(Diagnostic {
@@ -452,40 +537,6 @@ impl PartialDefinitionRegistry {
             names: self.names,
             _private: std::marker::PhantomData {},
         })
-    }
-
-    pub fn insert(&mut self, definition: Definition) -> DefinitionRef {
-        #[allow(clippy::single_match_else, reason = "May add more cases in the future")]
-        match definition {
-            Definition::Json(ref json) => {
-                let dependencies: Vec<_> = json
-                    .fields
-                    .iter()
-                    .filter_map(|field| match field.type_ {
-                        DataType::Definition(def_idx) => Some(def_idx),
-
-                        _ => None,
-                    })
-                    .collect();
-
-                let name = definition.name().clone();
-                let idx = self.definitions.add_node(definition);
-                self.names.insert(name, idx);
-                for &dependency in &dependencies {
-                    self.definitions.add_edge(dependency, idx, ());
-                }
-
-                idx
-            }
-
-            _ => {
-                let name = definition.name().clone();
-                let idx = self.definitions.add_node(definition);
-                self.names.insert(name, idx);
-
-                idx
-            }
-        }
     }
 
     // #[must_use]
@@ -551,7 +602,10 @@ mod tests {
                 index: 0,
                 name: "has_foo".into(),
                 key: String::from("bar"),
-                type_: DataType::Definition(foo_struct),
+                type_: DataType::Definition {
+                    definition: foo_struct,
+                    encoding: JsonEncoding::Json,
+                },
                 optional: false,
                 doc: String::from("some documentation"),
                 span: SourceSpan::from((0, 0)),

--- a/src/kdl_parser/mod.rs
+++ b/src/kdl_parser/mod.rs
@@ -336,8 +336,8 @@ mod document_to_intermediate {
             Definition, Encoding, Json, JsonField, PartialDefinitionRegistry,
         },
         kdl_parser::schema::{
-            self, BoolEncoding, DataType as SchemaDataType, JsonDefinition as SchemaJsonDefinition,
-            JsonField as SchemaJsonField, TypeEncoding,
+            self, BoolEncoding, DataType as SchemaDataType, IntLikeEncoding,
+            JsonDefinition as SchemaJsonDefinition, JsonField as SchemaJsonField,
         },
     };
 
@@ -347,46 +347,46 @@ mod document_to_intermediate {
     ) -> intermediate::DataType {
         match type_ {
             schema::DataType::I32 { encoding } => match encoding {
-                TypeEncoding::String => IntermediateDataType::I32 {
+                IntLikeEncoding::String => IntermediateDataType::I32 {
                     encoding: Encoding::String,
                 },
-                TypeEncoding::Int => IntermediateDataType::I32 {
+                IntLikeEncoding::Int => IntermediateDataType::I32 {
                     encoding: Encoding::Int,
                 },
             },
 
             SchemaDataType::U32 { encoding } => match encoding {
-                TypeEncoding::String => IntermediateDataType::U32 {
+                IntLikeEncoding::String => IntermediateDataType::U32 {
                     encoding: Encoding::String,
                 },
-                TypeEncoding::Int => IntermediateDataType::U32 {
+                IntLikeEncoding::Int => IntermediateDataType::U32 {
                     encoding: Encoding::Int,
                 },
             },
 
             SchemaDataType::I64 { encoding } => match encoding {
-                TypeEncoding::String => IntermediateDataType::I64 {
+                IntLikeEncoding::String => IntermediateDataType::I64 {
                     encoding: Encoding::String,
                 },
-                TypeEncoding::Int => IntermediateDataType::I64 {
+                IntLikeEncoding::Int => IntermediateDataType::I64 {
                     encoding: Encoding::Int,
                 },
             },
 
             SchemaDataType::U64 { encoding } => match encoding {
-                TypeEncoding::String => IntermediateDataType::U64 {
+                IntLikeEncoding::String => IntermediateDataType::U64 {
                     encoding: Encoding::String,
                 },
-                TypeEncoding::Int => IntermediateDataType::U64 {
+                IntLikeEncoding::Int => IntermediateDataType::U64 {
                     encoding: Encoding::Int,
                 },
             },
 
             SchemaDataType::F32 { encoding } => match encoding {
-                TypeEncoding::String => IntermediateDataType::F32 {
+                IntLikeEncoding::String => IntermediateDataType::F32 {
                     encoding: Encoding::String,
                 },
-                TypeEncoding::Int => IntermediateDataType::F32 {
+                IntLikeEncoding::Int => IntermediateDataType::F32 {
                     encoding: Encoding::Int,
                 },
             },
@@ -412,34 +412,44 @@ mod document_to_intermediate {
 
             SchemaDataType::String => IntermediateDataType::String,
 
-            SchemaDataType::Array(datatype) => IntermediateDataType::Array {
-                inner_type: Arc::new(convert_datatype_recursive(datatype, registry)),
+            SchemaDataType::Array { inner, size } => IntermediateDataType::Array {
+                inner_type: Arc::new(convert_datatype_recursive(inner, registry)),
+                size: (*size).into(),
             },
 
-            SchemaDataType::StringArray { inner, separator } => {
+            SchemaDataType::StringArray {
+                inner,
+                separator,
+                size,
+            } => {
                 use crate::kdl_parser::schema;
+
+                let size = (*size).into();
 
                 match separator {
                     schema::ArraySeparator::Comma => intermediate::DataType::StringArray {
                         separator: intermediate::ArraySeparator::Comma,
                         inner_type: Arc::new(convert_datatype_recursive(inner, registry)),
+                        size,
+                    },
+
+                    schema::ArraySeparator::Pipe => intermediate::DataType::StringArray {
+                        separator: intermediate::ArraySeparator::Pipe,
+                        inner_type: Arc::new(convert_datatype_recursive(inner, registry)),
+                        size,
                     },
 
                     schema::ArraySeparator::At => intermediate::DataType::StringArray {
                         separator: intermediate::ArraySeparator::At,
                         inner_type: Arc::new(convert_datatype_recursive(inner, registry)),
+                        size,
                     },
 
                     schema::ArraySeparator::Colon => intermediate::DataType::StringArray {
                         separator: intermediate::ArraySeparator::Colon,
                         inner_type: Arc::new(convert_datatype_recursive(inner, registry)),
+                        size,
                     },
-                }
-            }
-
-            SchemaDataType::SingleElementArray(data_type) => {
-                intermediate::DataType::SingleElementArray {
-                    inner_type: Arc::new(convert_datatype_recursive(data_type, registry)),
                 }
             }
 
@@ -448,11 +458,17 @@ mod document_to_intermediate {
                 value: Arc::new(convert_datatype_recursive(value, registry)),
             },
 
-            SchemaDataType::Custom(s) => {
-                if let Some(idx) = registry.find_weak(s) {
-                    intermediate::DataType::Definition(idx)
+            SchemaDataType::Custom { encoding, name } => {
+                if let Some(idx) = registry.find_weak(name) {
+                    intermediate::DataType::Definition {
+                        encoding: (*encoding).into(),
+                        definition: idx,
+                    }
                 } else {
-                    intermediate::DataType::Unknown(s.to_owned())
+                    intermediate::DataType::Unknown {
+                        encoding: (*encoding).into(),
+                        name: name.to_owned(),
+                    }
                 }
             }
         }

--- a/src/kdl_parser/parser/json_parser.rs
+++ b/src/kdl_parser/parser/json_parser.rs
@@ -6,7 +6,7 @@ use miette::Severity;
 use crate::kdl_parser::{
     Diagnostic, ParsingError, SourceInfo,
     parser::{ErrorContext, KdlDocumentUtilsExt, KdlNodeUtilsExt, type_parser::generic_parse},
-    schema::{JsonDefinition, JsonField, TypeEncoding},
+    schema::{IntLikeEncoding, JsonDefinition, JsonField},
 };
 
 const DEFAULT_ENCODING_PROPERTY: &str = "default-encoding";
@@ -51,7 +51,7 @@ pub fn parse_data_definition(
             })
         })
         .transpose()?
-        .map(TypeEncoding::from_str)
+        .map(IntLikeEncoding::from_str)
         .transpose()
         .map_err(|e| {
             ParsingError::from(Diagnostic {
@@ -146,7 +146,7 @@ fn parse_field(
     node: &KdlNode,
     source_code: Arc<SourceInfo>,
     data_name: &str,
-    maybe_default_encoding: Option<TypeEncoding>,
+    maybe_default_encoding: Option<IntLikeEncoding>,
     index: usize,
 ) -> Result<JsonField, ParsingError> {
     let field_node = node.extract_argument_string(
@@ -162,7 +162,7 @@ fn parse_field(
     let maybe_encoding = node
         .get("encoding")
         .and_then(|v| v.as_string())
-        .map(TypeEncoding::from_str)
+        .map(IntLikeEncoding::from_str)
         .transpose()
         .map_err(|e| {
             ParsingError::from(Diagnostic {

--- a/src/kdl_parser/parser/type_parser.rs
+++ b/src/kdl_parser/parser/type_parser.rs
@@ -5,13 +5,13 @@ use winnow::{LocatingSlice, Parser};
 
 use crate::kdl_parser::SourceInfo;
 use crate::kdl_parser::parser::type_parser::combinators::Error;
-use crate::kdl_parser::{Diagnostic, ParsingError, schema::TypeEncoding};
+use crate::kdl_parser::{Diagnostic, ParsingError, schema::IntLikeEncoding};
 
 use crate::kdl_parser::schema::DataType;
 
 pub fn generic_parse(
     input: &str,
-    _encoding: Option<TypeEncoding>,
+    _encoding: Option<IntLikeEncoding>,
     source_code: &Arc<SourceInfo>,
     span: SourceSpan,
 ) -> Result<DataType, ParsingError> {
@@ -92,9 +92,12 @@ fn convert_error_to_diagnostic(
 #[allow(dead_code)]
 mod combinators {
     use std::fmt::Display;
+    use std::num::NonZeroUsize;
     use std::sync::Arc;
 
-    use crate::kdl_parser::schema::{ArraySeparator, BoolEncoding, DataType, TypeEncoding};
+    use crate::kdl_parser::schema::{
+        ArraySeparator, ArraySize, BoolEncoding, DataType, IntLikeEncoding, JsonEncoding,
+    };
     use miette::SourceSpan;
     use winnow::ascii::{alpha1, alphanumeric1, space0, space1};
     use winnow::combinator::{
@@ -278,8 +281,8 @@ mod combinators {
                                 });
 
                             let last_encoding = valid_modifiers.last().and_then(|s| match s.name {
-                                "int" => Some(TypeEncoding::Int),
-                                "str" => Some(TypeEncoding::String),
+                                "int" => Some(IntLikeEncoding::Int),
+                                "str" => Some(IntLikeEncoding::String),
                                 _ => None,
                             });
 
@@ -428,10 +431,26 @@ mod combinators {
 
         (alphanumeric1, (not(alphanumeric1), opt(parse_modifier)))
             .try_map(
-                |(name, _maybe_modifiers)| -> Result<DataType, MiniDiagnostic> {
+                |(name, ((), maybe_modifiers))| -> Result<DataType, MiniDiagnostic> {
                     error_on_python_datatype(name)?;
 
-                    Ok(DataType::Custom(name.into()))
+                    let encoding = maybe_modifiers
+                        .and_then(|modifiers| {
+                            modifiers
+                                .iter()
+                                .filter_map(|modifier| match modifier.name {
+                                    "str" => Some(JsonEncoding::String),
+                                    "json" => Some(JsonEncoding::Json),
+                                    _ => None,
+                                })
+                                .next_back()
+                        })
+                        .unwrap_or(JsonEncoding::Json);
+
+                    Ok(DataType::Custom {
+                        encoding,
+                        name: name.into(),
+                    })
                 },
             )
             .parse_next(input)
@@ -464,22 +483,82 @@ mod combinators {
     fn parse_array(input: &mut Input) -> PResult {
         #[derive(Debug, Clone)]
         enum PartialArrayType {
-            SingleElement,
-            StringArray { separator: ArraySeparator },
-            NormalArray,
+            StringArray {
+                separator: ArraySeparator,
+                size: ArraySize,
+            },
+            NormalArray {
+                size: ArraySize,
+            },
         }
 
         (delimited("[", parse_datatype, "]"),
             cut_err(opt(parse_modifier).try_map(|maybe_modifiers| {
                 match maybe_modifiers {
 
-                None => Ok(PartialArrayType::NormalArray),
+                None => Ok(PartialArrayType::NormalArray { size: ArraySize::Dynamic }),
 
                 Some(modifiers) => {
 
-                    let possible_array_types: Result<Vec<_>, MiniDiagnostic> = modifiers
+                    let array_sizes =
+                        modifiers
                         .iter()
                         .filter_map(|modifier| -> Option<Result<_, MiniDiagnostic>> {
+
+                            match modifier.name {
+                                "size" => {
+                                    let res = modifier
+                                        .params
+                                        .first()
+                                        .ok_or_else(|| MiniDiagnostic {
+                                            message: "array modifier `size` needs to include the number of elements".to_owned(),
+                                            severity: miette::Severity::Error,
+                                            help: Some("add one of `::size(1)`, `::size(n)`".to_owned()),
+                                        })
+                                        .and_then(|&size| {
+                                            if size == "n" {
+                                                 Ok(ArraySize::Dynamic)
+                                            } else {
+                                                // Try to parse as an integer.
+                                                let n = size.parse::<usize>().map_err(|_e| {
+                                                        MiniDiagnostic {
+                                                            message: format!("unexpected argument value `{size}` in array modifier `size`"),
+                                                            severity: miette::Severity::Error,
+                                                            help: Some("use one of `::size(1)`, `::size(42)` or `::size(n)`".to_owned()),
+                                                        }
+                                                    })?;
+
+                                                match NonZeroUsize::new(n) {
+                                                    Some(v) => Ok(ArraySize::Fixed(v)),
+
+                                                    None => Err(MiniDiagnostic {
+                                                        message: format!("fixed array size `{size}` is <= 0"),
+                                                        severity: (miette::Severity::Error),
+                                                        help: Some("use a strictly positive size such as `::size(42)`".to_owned()),
+                                                    })
+                                                }
+                                            }
+                                        });
+
+                                    Some(res)
+                                }
+
+                                _ => None,
+                            }
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+
+                    if array_sizes.len() > 1 {
+                        return Err(MiniDiagnostic {
+                            message: ("multiple sizes specified for array").into(),
+                            severity: miette::Severity::Error,
+                            help: Some("please specify only one size between `::size(1)`, `::size(42)`, `::size(n)`".into()),
+                        });
+                    }
+
+                    let array_size = array_sizes.first().copied().unwrap_or_default();
+
+                    let maybe_separators: Result<Vec<_>, _> = modifiers.iter().filter_map(|modifier| -> Option<Result<_, MiniDiagnostic>> {
                             match modifier.name {
                                 "sep" => {
                                     let x = modifier
@@ -495,73 +574,47 @@ mod combinators {
                                                 "at" => Ok(ArraySeparator::At),
                                                 "colon" => Ok(ArraySeparator::Colon),
                                                 "comma" => Ok(ArraySeparator::Comma),
+                                                "pipe" => Ok(ArraySeparator::Pipe),
                                                 _ => Err(MiniDiagnostic {
                                                     message: format!("unknown separator {sep}"),
                                                     severity: miette::Severity::Error,
-                                                    help: Some("use one of `::sep(at)`, `::sep(colon)`, `::sep(comma)`".to_owned()),
+                                                    help: Some("use one of `::sep(at)`, `::sep(colon)`, `::sep(pipe)`, `::sep(comma)`".to_owned()),
                                                 })
                                             }
                                         })
                                         .map(|separator| {
-                                            PartialArrayType::StringArray { separator }
+                                            PartialArrayType::StringArray { separator, size: array_size }
                                         });
 
                                     Some(x)
                                 }
 
-                                "size" => {
-                                    let x = modifier
-                                        .params
-                                        .first()
-                                        .ok_or_else(|| MiniDiagnostic {
-                                            message: "array modifier `size` needs to include the number of elements".to_owned(),
-                                            severity: miette::Severity::Error,
-                                            help: Some("add one of `::size(1)`, `::size(n)`".to_owned()),
-                                        })
-                                        .and_then(|&size| {
-                                            match size {
-                                                "1" => Ok(PartialArrayType::SingleElement),
-                                                "n" => Ok(PartialArrayType::NormalArray),
-                                                _ => Err(MiniDiagnostic {
-                                                    message: format!("unrecognized size `{size}` in array size modifier declaration"),
-                                                    severity: (miette::Severity::Error),
-                                                    help: Some("use one of `::size(1)` or `::size(n)`".to_owned()),
-                                                })
-                                            }
-                                        });
-
-                                    Some(x)
-                                }
-
-                                _ => None,
+                                _ => None
                             }
-                        })
-                        .collect();
+                        }).collect();
 
-                    let array_types = possible_array_types?;
+                    let maybe_separators = maybe_separators?;
 
-
-                    if array_types.len() > 1 {
+                    if maybe_separators.len() > 1 {
                         return Err(MiniDiagnostic {
-                            message: "multiple conflicting array modifiers, specify either `::size` or `::sep`, but not both".to_owned(),
+                            message: ("multiple separators specified for string array").into(),
                             severity: miette::Severity::Error,
-                            help: None,
-                        })
+                            help: Some("please specify only one separator.".into()),
+                        });
                     }
 
-                    match array_types.first() {
-                            Some(elem) => Ok(elem.clone()),
-                            None => Ok(PartialArrayType::NormalArray),
-                    }
+                    Ok(maybe_separators.first().cloned().unwrap_or(PartialArrayType::NormalArray { size: array_size }))
                 }
             }
             })
             ))
             .map(|(inner, array_type)| {
                 match array_type {
-                    PartialArrayType::SingleElement => DataType::SingleElementArray(inner.into()),
-                    PartialArrayType::NormalArray => DataType::Array(inner.into()),
-                    PartialArrayType::StringArray { separator } => DataType::StringArray { inner: inner.into(), separator},
+                    PartialArrayType::NormalArray { size} => DataType::Array{
+                        size,
+                        inner: inner.into()
+                    },
+                    PartialArrayType::StringArray { size,  separator } => DataType::StringArray { inner: inner.into(), separator, size },
                 }
             })
             .parse_next(input)
@@ -618,7 +671,7 @@ mod combinators {
 
     #[cfg(test)]
     mod tests {
-        use crate::kdl_parser::schema::{DataType, TypeEncoding};
+        use crate::kdl_parser::schema::{DataType, IntLikeEncoding};
 
         use super::*;
 
@@ -645,7 +698,7 @@ mod combinators {
             assert!(matches!(
                 val,
                 Ok(DataType::I32 {
-                    encoding: TypeEncoding::String
+                    encoding: IntLikeEncoding::String
                 })
             ));
         }
@@ -661,7 +714,7 @@ mod combinators {
             assert!(matches!(
                 val,
                 Ok(DataType::I32 {
-                    encoding: TypeEncoding::String
+                    encoding: IntLikeEncoding::String
                 })
             ));
         }
@@ -677,7 +730,7 @@ mod combinators {
             assert!(matches!(
                 val,
                 Ok(DataType::I32 {
-                    encoding: TypeEncoding::Int
+                    encoding: IntLikeEncoding::Int
                 })
             ));
         }
@@ -763,7 +816,7 @@ mod combinators {
                 state: State {},
             };
             let val = parse_datatype(&mut input);
-            assert!(matches!(val, Ok(DataType::SingleElementArray { .. })));
+            assert!(matches!(val, Ok(DataType::Array { .. })));
         }
 
         #[test]
@@ -796,7 +849,13 @@ mod combinators {
                 state: State {},
             };
             let val = parse_datatype(&mut input);
-            assert!(matches!(val, Ok(DataType::Custom(..))));
+            assert!(matches!(
+                val,
+                Ok(DataType::Custom {
+                    encoding: JsonEncoding::Json,
+                    ..
+                })
+            ));
         }
 
         #[test]
@@ -813,7 +872,13 @@ mod combinators {
                 };
                 let val = parse_datatype(&mut input);
                 assert!(!matches!(val, Ok(DataType::String)));
-                assert!(matches!(val, Ok(DataType::Custom(..))));
+                assert!(matches!(
+                    val,
+                    Ok(DataType::Custom {
+                        encoding: JsonEncoding::Json,
+                        ..
+                    })
+                ));
             }
         }
 

--- a/src/kdl_parser/schema/mod.rs
+++ b/src/kdl_parser/schema/mod.rs
@@ -1,4 +1,6 @@
-use std::{collections::BTreeSet, fmt::Display, path::PathBuf, str::FromStr, sync::Arc};
+use std::{
+    collections::BTreeSet, fmt::Display, num::NonZeroUsize, path::PathBuf, str::FromStr, sync::Arc,
+};
 
 mod validator;
 
@@ -153,13 +155,37 @@ pub struct HTTPProperty {
 
     pub r#type: DataType,
 
-    pub r#encoding: Option<TypeEncoding>,
+    pub r#encoding: Option<IntLikeEncoding>,
 
     pub key: String,
 
     pub doc: String,
 
     pub escape: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum JsonEncoding {
+    Json,
+    String,
+}
+
+impl Display for JsonEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json => write!(f, "json"),
+            Self::String => write!(f, "str"),
+        }
+    }
+}
+
+impl From<JsonEncoding> for crate::intermediate::JsonEncoding {
+    fn from(value: JsonEncoding) -> Self {
+        match value {
+            JsonEncoding::Json => Self::Json,
+            JsonEncoding::String => Self::String,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -201,6 +227,13 @@ pub enum ArraySeparator {
     /// ## Example
     ///
     /// [i32] = "1|3|4|5|6"
+    Pipe,
+
+    /// Array separated by ':'
+    ///
+    /// ## Example
+    ///
+    /// [i32] = "1:3:4:5:6"
     Colon,
 }
 
@@ -211,9 +244,10 @@ impl FromStr for ArraySeparator {
         match s {
             "," => Ok(Self::Comma),
             "@" => Ok(Self::At),
-            "|" => Ok(Self::Colon),
+            ":" => Ok(Self::Colon),
+            "|" => Ok(Self::Pipe),
             _ => Err(
-                "expected to find one of `,` (comma), `@` (at), or `|` (colon) as array separator",
+                "expected to find one of `,` (comma), `@` (at), `|` (pipe), or `:` (colon) as array separator",
             ),
         }
     }
@@ -224,7 +258,36 @@ impl Display for ArraySeparator {
         match self {
             Self::Comma => write!(f, ","),
             Self::At => write!(f, "@"),
-            Self::Colon => write!(f, "|"),
+            Self::Pipe => write!(f, "|"),
+            Self::Colon => write!(f, ":"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub enum ArraySize {
+    #[default]
+    /// Array of unbounded elements.
+    Dynamic,
+
+    /// Array of exactly N elements.
+    Fixed(NonZeroUsize),
+}
+
+impl Display for ArraySize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Dynamic => write!(f, "size(n)"),
+            Self::Fixed(size) => write!(f, "size({size})"),
+        }
+    }
+}
+
+impl From<ArraySize> for crate::intermediate::ArraySize {
+    fn from(value: ArraySize) -> Self {
+        match value {
+            ArraySize::Dynamic => Self::Dynamic,
+            ArraySize::Fixed(n) => Self::Fixed(n),
         }
     }
 }
@@ -233,23 +296,23 @@ impl Display for ArraySeparator {
 #[allow(dead_code)]
 pub enum DataType {
     I32 {
-        encoding: TypeEncoding,
+        encoding: IntLikeEncoding,
     },
 
     U32 {
-        encoding: TypeEncoding,
+        encoding: IntLikeEncoding,
     },
 
     I64 {
-        encoding: TypeEncoding,
+        encoding: IntLikeEncoding,
     },
 
     U64 {
-        encoding: TypeEncoding,
+        encoding: IntLikeEncoding,
     },
 
     F32 {
-        encoding: TypeEncoding,
+        encoding: IntLikeEncoding,
     },
 
     // NOTE(anri, 2026-01-11): a string-encoded 64-bit float does not exist yet.
@@ -267,17 +330,18 @@ pub enum DataType {
 
     String,
 
+    /// An array represented as a native array type.
+    Array {
+        size: ArraySize,
+        inner: Arc<Self>,
+    },
+
     /// An array typically represented as a string separated by a separator.
     StringArray {
         inner: Arc<Self>,
         separator: ArraySeparator,
+        size: ArraySize,
     },
-
-    /// A normal array.
-    Array(Arc<Self>),
-
-    /// Like `Array` but it only holds a single element.
-    SingleElementArray(Arc<Self>),
 
     /// Dictionary from one type to another.
     Map {
@@ -286,7 +350,10 @@ pub enum DataType {
     },
 
     // Tuple(Vec<DataType>),
-    Custom(String),
+    Custom {
+        name: String,
+        encoding: JsonEncoding,
+    },
 }
 
 impl Display for DataType {
@@ -302,22 +369,25 @@ impl Display for DataType {
             Self::Datetime => write!(f, "datetime"),
             Self::DatetimeUnix => write!(f, "datetime-unix"),
             Self::String => write!(f, "string"),
-            Self::Array(inner) => write!(f, "[{inner}]"),
-            Self::StringArray { inner, separator } => write!(f, "[{inner}{separator}]"),
-            Self::SingleElementArray(data_type) => write!(f, "[{data_type}]"),
+            Self::Array { size, inner } => write!(f, "[{inner}]::{size}"),
+            Self::StringArray {
+                inner,
+                separator,
+                size,
+            } => write!(f, "[{inner}{separator}]::{size}"),
             Self::Map { key, value } => write!(f, "{key} => {value}"),
-            Self::Custom(s) => write!(f, "{s}"),
+            Self::Custom { name, encoding } => write!(f, "{name}::{encoding}"),
         }
     }
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum TypeEncoding {
+pub enum IntLikeEncoding {
     String,
     Int,
 }
 
-impl FromStr for TypeEncoding {
+impl FromStr for IntLikeEncoding {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {


### PR DESCRIPTION
Other fixes:
 - Add pipe (|) separator to parser.
 - Fix colon (:) separator.
 - Correctly compute dependencies for all nested types.