### PR TITLE
fix: Move BadgeInfoResp + ChallengeArenaResetInfoResp into handlers.kdl; use datetime-unix::str for timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ cython_debug/
 .vscode/
 
 test_write/
+
+# Visual Studio
+.vs/

--- a/assets/net/badge_info.kdl
+++ b/assets/net/badge_info.kdl
@@ -32,11 +32,3 @@ json BadgeInfo {
     }
 }
 
-json BadgeInfoResp {
-    doc "TODO"
-
-    field badge_info type="BadgeInfo" {
-        key "h23iRjGN"
-        doc "TODO"
-    }
-}

--- a/assets/net/badge_info.kdl
+++ b/assets/net/badge_info.kdl
@@ -1,4 +1,3 @@
-
 json BadgeInfo {
     doc "TODO"
 
@@ -31,5 +30,13 @@ json BadgeInfo {
         key "dUujjBBK"
         doc "TODO"
     }
+}
 
+json BadgeInfoResp {
+    doc "TODO"
+
+    field badge_info type="BadgeInfo" {
+        key "h23iRjGN"
+        doc "TODO"
+    }
 }

--- a/assets/net/challenge_arena.kdl
+++ b/assets/net/challenge_arena.kdl
@@ -63,3 +63,36 @@ json ChallengeArenaUserInfo {
     }
 
 }
+
+json ChallengeArenaResetInfo {
+    doc "TODO"
+
+    field daily_cooling_start type="str" {
+        key "xQZe5il8"
+        doc "Daily cooling period start time"
+    }
+
+    field daily_cooling_end type="str" {
+        key "1fhT0oIQ"
+        doc "Daily cooling period end time"
+    }
+
+    field weekly_reset_time type="str" {
+        key "QRqWHfJG"
+        doc "Weekly reset time"
+    }
+
+    field server_time type="str" {
+        key "z1I0P1Qk"
+        doc "Current server time"
+    }
+}
+
+json ChallengeArenaResetInfoResp {
+    doc "TODO"
+
+    field reset_info type="ChallengeArenaResetInfo" {
+        key "t6bRQfln"
+        doc "TODO"
+    }
+}

--- a/assets/net/challenge_arena.kdl
+++ b/assets/net/challenge_arena.kdl
@@ -67,32 +67,24 @@ json ChallengeArenaUserInfo {
 json ChallengeArenaResetInfo {
     doc "TODO"
 
-    field daily_cooling_start type="str" {
+    field daily_cooling_start type="datetime-unix::str" {
         key "xQZe5il8"
         doc "Daily cooling period start time"
     }
 
-    field daily_cooling_end type="str" {
+    field daily_cooling_end type="datetime-unix::str" {
         key "1fhT0oIQ"
         doc "Daily cooling period end time"
     }
 
-    field weekly_reset_time type="str" {
+    field weekly_reset_time type="datetime-unix::str" {
         key "QRqWHfJG"
         doc "Weekly reset time"
     }
 
-    field server_time type="str" {
+    field server_time type="datetime-unix::str" {
         key "z1I0P1Qk"
         doc "Current server time"
     }
 }
 
-json ChallengeArenaResetInfoResp {
-    doc "TODO"
-
-    field reset_info type="ChallengeArenaResetInfo" {
-        key "t6bRQfln"
-        doc "TODO"
-    }
-}

--- a/assets/net/handlers.kdl
+++ b/assets/net/handlers.kdl
@@ -591,3 +591,21 @@ json FriendGetResp {
         doc "TODO"
     }
 }
+
+json ChallengeArenaResetInfoResp {
+    doc "Challenge Arena cooling/reset timer snapshot"
+
+    field reset_info type="ChallengeArenaResetInfo" {
+        key "t6bRQfln"
+        doc "Timestamps for daily cooling and weekly reset"
+    }
+}
+
+json BadgeInfoResp {
+    doc "TODO"
+
+    field badge_info type="BadgeInfo" {
+        key "h23iRjGN"
+        doc "TODO"
+    }
+}


### PR DESCRIPTION
## Changes
- Moved `BadgeInfoResp` from `net/badge_info.kdl` into `net/handlers.kdl` (kept `BadgeInfo` data struct in badge_info.kdl)
- Moved `ChallengeArenaResetInfoResp` from `net/challenge_arena.kdl` into `net/handlers.kdl` (kept `ChallengeArenaResetInfo` + `ChallengeArenaUserInfo` data structs)
- Changed `ChallengeArenaResetInfo` timestamp fields from `str` to `datetime-unix::str` (generates `pkg::chrono_time` with unix epoch serialization)

## Related
- decompfrontier/server#23