### PR TITLE
Add unit archive schema

### DIFF
--- a/assets/archive.kdl
+++ b/assets/archive.kdl
@@ -1,0 +1,1 @@
+import "archive/unit.kdl"

--- a/assets/archive/unit.kdl
+++ b/assets/archive/unit.kdl
@@ -1,0 +1,44 @@
+json UnitRecordStats {
+    doc "Generic hp, atk, def, rec stats for a given unit."
+
+    field hp type="u32::int" {
+        key "hp"
+        doc "hp of this unit."
+    }
+
+    field atk type="u32::int" {
+        key "atk"
+        doc "atk of this unit."
+    }
+
+    field def type="u32::int" {
+        key "def"
+        doc "def of this unit."
+    }
+
+    field rec type="u32::int" {
+        key "rec"
+        doc "rec of this unit."
+    }
+}
+
+json UnitRecord {
+    doc """
+    Server-owned curated unit archive data. This intentionally contains fewer
+    fields than the official unit MSTs because we should only preserve fields
+    that we understand and use.
+    """
+
+    field unit_id type="u32::int" {
+        key "unit_id"
+        doc """
+        Unique identifier for the unit's archive record.
+        Used to look up this unit when creating player-owned units.
+        """
+    }
+
+    field lord_stats type=UnitRecordStats {
+        key "lord_stats"
+        doc "Base stats for lord type."
+    }
+}

--- a/assets/net/handlers.kdl
+++ b/assets/net/handlers.kdl
@@ -25,6 +25,7 @@ import "../mst/sound.kdl"
 import "../mst/first_desc.kdl"
 import "../mst/frontier_hunter.kdl"
 import "../net/signal_key.kdl"
+import "../net/tutorial.kdl"
 import "../net/challenge_arena.kdl"
 import "../net/guild.kdl"
 import "../net/daily_login.kdl"
@@ -337,6 +338,25 @@ json UserInfoReq {
     field unk type="[UnkUserInfoNetReq]::size(1)" {
         key "563Dtye3"
         doc "TODO"
+    }
+}
+
+json CreateUserReq {
+    doc "Creates the game user after the tutorial name/starter prompt."
+
+    field loginInfo type="[LoginInfoReq]::size(1)" {
+        key "IKqx1Cn9"
+        doc "Login information containing user, Gumi Live, device, and handle fields."
+    }
+
+    field selectedElement type="[TutorialSelectedElement]::size(1)" {
+        key "9u45RGcV"
+        doc "Starter element selected by the player."
+    }
+
+    field mstRequests type="[MstUrlList]" {
+        key "KeC10fuL"
+        doc "MST versions requested by the client."
     }
 }
 

--- a/assets/net/tutorial.kdl
+++ b/assets/net/tutorial.kdl
@@ -1,0 +1,8 @@
+json TutorialSelectedElement {
+    doc "Starter element selected during the new-user tutorial."
+
+    field element type="u32::str" {
+        key "Kn51uR4Y"
+        doc "Selected starter element id sent by the client."
+    }
+}

--- a/assets/net/user.kdl
+++ b/assets/net/user.kdl
@@ -507,11 +507,14 @@ json UserTeamInfo {
 }
 
 json UserUnitInfo {
-    doc "TODO"
+    doc "Player-owned unit records."
 
-    field user_unit_id type="i32::str" {
+    field user_unit_id type="u32::str" {
         key "edy7fq3L"
-        doc "TODO"
+        doc """
+        Unique id attributed to a specific unit of a given user.
+        Duplicates of the same unit will receive unique user unit ids.
+        """
     }
 
     field user_id type="str" {
@@ -519,14 +522,20 @@ json UserUnitInfo {
         doc "ID of the user for this session."
     }
 
-    field unit_id type="i32::str" {
+    field unit_id type="u32::str" {
         key "pn16CNah"
-        doc "TODO"
+        doc """
+        Unique identifier for the unit's archive record.
+        Used to look up this unit in the MST assets.
+        """
     }
 
-    field unit_type_id type="i32::str" {
+    field unit_type_id type="u32::str" {
         key "nBTx56W9"
-        doc "TODO"
+        doc """
+        Specifies the unit type, e.g. Lord, Anima, Breaker, Guardian, or Oracle.
+        TODO: Figure out which numeric value maps to each type.
+        """
     }
 
     field unit_lv type="i32::str" {
@@ -544,9 +553,16 @@ json UserUnitInfo {
         doc "TODO"
     }
 
-    field base_hp type="i32::str" {
+    field base_hp type="u32::str" {
         key "e7DK0FQT"
-        doc "TODO"
+        doc """
+        Current HP stat for this unit before imp/stat-up bonuses.
+        Includes level-based stat growth because this client passes
+        base_hp into GameUtils::getUnitHp(base_hp, unit_lv, ...),
+        which currently returns base_hp unchanged. This suggests the
+        server is expected to store the unit's level-adjusted normal
+        HP in this bucket. Naturally, this applies to all base_* stats.
+        """
     }
 
     field add_hp type="i32::str" {
@@ -554,9 +570,12 @@ json UserUnitInfo {
         doc "TODO"
     }
 
-    field ext_hp type="i32::str" {
+    field ext_hp type="u32::str" {
         key "TokWs1B3"
-        doc "TODO"
+        doc """
+        Imp/stat-up HP bucket.
+        We should cap this against the unit's HP stat-up limit from MST data.
+        """
     }
 
     field limit_over_hp type="i32::int" {
@@ -564,9 +583,12 @@ json UserUnitInfo {
         doc "TODO"
     }
 
-    field base_atk type="i32::str" {
+    field base_atk type="u32::str" {
         key "67CApcti"
-        doc "TODO"
+        doc """
+        Current ATK stat for this unit before imp/stat-up bonuses.
+        See base_hp for why base_* stores the unit's level-adjusted normal stats.
+        """
     }
 
     field add_atk type="i32::str" {
@@ -574,9 +596,12 @@ json UserUnitInfo {
         doc "TODO"
     }
 
-    field ext_atk type="i32::str" {
+    field ext_atk type="u32::str" {
         key "t4m1RH6Y"
-        doc "TODO"
+        doc """
+        Imp/stat-up ATK bucket.
+        We should cap this against the unit's ATK stat-up limit from MST data.
+        """
     }
 
     field limit_over_atk type="i32::int" {
@@ -584,9 +609,12 @@ json UserUnitInfo {
         doc "TODO"
     }
 
-    field base_def type="i32::str" {
+    field base_def type="u32::str" {
         key "q08xLEsy"
-        doc "TODO"
+        doc """
+        Current DEF stat for this unit before imp/stat-up bonuses.
+        See base_hp for why base_* stores the unit's level-adjusted normal stats.
+        """
     }
 
     field add_def type="i32::str" {
@@ -594,9 +622,12 @@ json UserUnitInfo {
         doc "TODO"
     }
 
-    field ext_def type="i32::str" {
+    field ext_def type="u32::str" {
         key "e6mY8Z0k"
-        doc "TODO"
+        doc """
+        Imp/stat-up DEF bucket.
+        We should cap this against the unit's DEF stat-up limit from MST data.
+        """
     }
 
     field limit_over_def type="i32::int" {
@@ -604,22 +635,28 @@ json UserUnitInfo {
         doc "TODO"
     }
 
-    field base_heal type="i32::str" {
+    field base_rec type="u32::str" {
         key "PWXu25cg"
-        doc "TODO"
+        doc """
+        Current REC stat for this unit before imp/stat-up bonuses.
+        See base_hp for why base_* stores the unit's level-adjusted normal stats.
+        """
     }
 
-    field add_heal type="i32::str" {
+    field add_rec type="i32::str" {
         key "C1HZr3pb"
         doc "TODO"
     }
 
-    field ext_heal type="i32::str" {
+    field ext_rec type="u32::str" {
         key "X6jf8DUw"
-        doc "TODO"
+        doc """
+        Imp/stat-up REC bucket.
+        We should cap this against the unit's REC stat-up limit from MST data.
+        """
     }
 
-    field limit_over_heal type="i32::int" {
+    field limit_over_rec type="i32::int" {
         key "XJs2rPx0"
         doc "TODO"
     }

--- a/assets/net/user.kdl
+++ b/assets/net/user.kdl
@@ -824,6 +824,11 @@ json LoginInfoReq {  // # TODO: actually support (GumiLiveInfo), as it's not sup
         doc "TODO"
     }
 
+    field unk5 type="i32::str" {
+        key "37d2Hi5p"
+        doc "TODO"
+    }
+
     field device_id type="str" {
         key "Ma5GnU0H"
         doc "Device advertisement ID (the same as vid in the gumi api login)"

--- a/src/generators/cpp/mod.rs
+++ b/src/generators/cpp/mod.rs
@@ -301,11 +301,11 @@ fn generate_json_cxx(
             }
 
             let name = struct_field_format(&field.name);
-            let doc = split_documentation(&field.doc, 0);
+            let doc = split_documentation(&field.doc, 1);
 
             Ok(format!(
                 "
-{TAB}{doc}
+{doc}
 {TAB}{datatype} {name};"
             ))
         })


### PR DESCRIPTION
## Summary
- add archive/unit.kdl for curated unit archive data
- generate UnitRecord and UnitRecordStats schemas
- document the DB-backed UserUnitInfo stat fields used by the server
- keep generated C++ field docs correctly indented

## Testing
- generated server headers via py generate.py in the server repo
- built server with cmake --build . --config Debug